### PR TITLE
Converts footer to analytics.js from ga.js

### DIFF
--- a/development.html
+++ b/development.html
@@ -1,4 +1,8 @@
-3.0i
+Development footer 3.2
+<style>
+#rtac_panel{display:none !important}
+</style>
+
 <style type="text/css">
 <!--
 /* Grids */
@@ -17,9 +21,10 @@
 .last-item{float:none;width:auto;_position:relative;_left:-3px;_margin-right:-3px;}
 
 .branding-container {
-                margin: 0 auto;
-                width:800px;
-                text-align:center;
+	margin: 0 auto;
+	width:800px;
+	text-align:center;
+	z-index: 999;
 }
 
 
@@ -158,6 +163,7 @@ div#bartonplus_placard iframe {
 .externalLinks .custom-link:last-child {
 	border-right: none;
 }
+
 //-->
 </style>
 
@@ -204,15 +210,23 @@ div#bartonplus_placard iframe {
 </div>
 <script type="text/javascript">
 
-	var _gaq = _gaq || [];
-	_gaq.push(['_setAccount', 'UA-1760176-32']);
-	_gaq.push(['_trackPageview']);
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
-	(function() {
-		var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-		ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-		var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-	})();
+	// The Production EDS property ID under Google Analytics
+	// var propertyID = 'UA-1760176-1';
+	// var propertyArray = ['libraries.mit.edu', 'libguides.mit.edu', 'libcal.mit.edu', 'libanswers.mit.edu'];
+
+	// The Development EDS property ID under Google Analytics
+	var propertyID = 'UA-1760176-26';
+	var propertyArray = ['libraries-dev.mit.edu', 'libraries-test.mit.edu'];
+
+	ga('create', propertyID, 'auto', {'allowLinker': true});
+	ga('require', 'linker');
+	ga('linker:autoLink', propertyArray);
+	ga('send', 'pageview');
 
 	// This comes from the EBSCO Administration wiki
 	var trackCall = setInterval(function () {
@@ -252,6 +266,7 @@ div#bartonplus_placard iframe {
 // v2.9 Adding pipes between custom links in search result list (CSS only)
 // v3.0 Reworking recording of returned results, and clicks thereupon
 // v3.1 Removing red "beta-banner" bar as a test
+// v3.2 Switches to new Google Analytics script
 
 		var strFormAction;
 
@@ -596,9 +611,14 @@ div#bartonplus_placard iframe {
 	}
 
 	function TrackEvent(Category,Action,Label,Value){
-		_gaq.push(['_trackEvent', Category, Action, Label, Value]);
+		ga('send', {
+			hitType: 'event',
+			eventCategory: Category,
+			eventAction: Action,
+			eventLabel: Label,
+			eventValue: Value
+		});
 		console.log('C'+Category+' _ A'+Action+' _ L'+Label+' _ V'+Value);
 	}
-
 
 </script>

--- a/production.html
+++ b/production.html
@@ -209,16 +209,21 @@ div#bartonplus_placard iframe {
 </div>
 <script type="text/javascript">
 
-	var _gaq = _gaq || [];
-	// The Production EDS property ID under Google Analytics
-	_gaq.push(['_setAccount', 'UA-1760176-20']);
-	_gaq.push(['_trackPageview']);
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
-	(function() {
-		var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-		ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-		var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-	})();
+	// The Production EDS property ID under Google Analytics
+	var propertyID = 'UA-1760176-1';
+	var propertyArray = ['libraries.mit.edu', 'libguides.mit.edu', 'libcal.mit.edu', 'libanswers.mit.edu'];
+	// The Development EDS property ID under Google Analytics
+	// var propertyID = 'UA-1760176-26';
+	// var propertyArray = ['libraries-dev.mit.edu', 'libraries-test.mit.edu'];
+	ga('create', propertyID, 'auto', {'allowLinker': true});
+	ga('require', 'linker');
+	ga('linker:autoLink', propertyArray);
+	ga('send', 'pageview');
 
 	// This comes from the EBSCO Administration wiki
 	var trackCall = setInterval(function () {
@@ -264,6 +269,7 @@ div#bartonplus_placard iframe {
 // v3.5 Modified footer as per Remlee Green email on 10-06-2014 (rw) 
 // v3.6 Added SSO note to beta-banner (mb)
 // v3.7 Removing beta-banner (mb)
+// v3.8 Converting Google Analytics to use analytics.js (mb)
 
 		var strFormAction;
 
@@ -562,7 +568,13 @@ div#bartonplus_placard iframe {
 	}
 
 	function TrackEvent(Category,Action,Label,Value){
-		_gaq.push(['_trackEvent', Category, Action, Label, Value]);
+		ga('send', {
+			hitType: 'event',
+			eventCategory: Category,
+			eventAction: Action,
+			eventLabel: Label,
+			eventValue: Value
+		});
 	}
 
 </script>

--- a/production.html
+++ b/production.html
@@ -217,9 +217,11 @@ div#bartonplus_placard iframe {
 	// The Production EDS property ID under Google Analytics
 	var propertyID = 'UA-1760176-1';
 	var propertyArray = ['libraries.mit.edu', 'libguides.mit.edu', 'libcal.mit.edu', 'libanswers.mit.edu'];
+
 	// The Development EDS property ID under Google Analytics
 	// var propertyID = 'UA-1760176-26';
 	// var propertyArray = ['libraries-dev.mit.edu', 'libraries-test.mit.edu'];
+
 	ga('create', propertyID, 'auto', {'allowLinker': true});
 	ga('require', 'linker');
 	ga('linker:autoLink', propertyArray);

--- a/testing.html
+++ b/testing.html
@@ -21,9 +21,9 @@ Testing footer 4.1.0
 .last-item{float:none;width:auto;_position:relative;_left:-3px;_margin-right:-3px;}
 
 .branding-container {
-    margin: 0 auto;
-    width:800px;
-    text-align:center;
+	margin: 0 auto;
+	width:800px;
+	text-align:center;
 	z-index: 999;
 }
 
@@ -217,11 +217,15 @@ div#bartonplus_placard iframe {
 
 	// The Production EDS property ID under Google Analytics
 	// var propertyID = 'UA-1760176-1';
+	// var propertyArray = ['libraries.mit.edu', 'libguides.mit.edu', 'libcal.mit.edu', 'libanswers.mit.edu'];
+
 	// The Development EDS property ID under Google Analytics
 	var propertyID = 'UA-1760176-26';
+	var propertyArray = ['libraries-dev.mit.edu', 'libraries-test.mit.edu'];
+
 	ga('create', propertyID, 'auto', {'allowLinker': true});
 	ga('require', 'linker');
-	ga('linker:autoLink', ['libraries-dev.mit.edu', 'libraries-test.mit.edu'] );
+	ga('linker:autoLink', propertyArray);
 	ga('send', 'pageview');
 
 	// This comes from the EBSCO Administration wiki

--- a/testing.html
+++ b/testing.html
@@ -1,4 +1,4 @@
-Testing footer 4.0.0
+Testing footer 4.1.0
 <style>
 #rtac_panel{display:none !important}
 </style>
@@ -210,18 +210,16 @@ div#bartonplus_placard iframe {
 </div>
 <script type="text/javascript">
 
-	var _gaq = _gaq || [];
-	// The Production EDS property ID under Google Analytics
-	// _gaq.push(['_setAccount', 'UA-1760176-20']);
-	// The Development EDS property ID under Google Analytics
-	_gaq.push(['_setAccount', 'UA-1760176-32']);
-	_gaq.push(['_trackPageview']);
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
-	(function() {
-		var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-		ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-		var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-	})();
+	// The Production EDS property ID under Google Analytics
+	// ga('create', 'UA-1760176-20', 'auto');
+	// The Development EDS property ID under Google Analytics
+	ga('create', 'UA-1760176-32', 'auto');
+	ga('send', 'pageview');
 
 	// This comes from the EBSCO Administration wiki
 	var trackCall = setInterval(function () {
@@ -268,6 +266,7 @@ div#bartonplus_placard iframe {
 	// v3.6 Added SSO note to beta-banner (mb)
 	// v3.7 Removing beta-banner (mb)
 	// v4.0.0 Semantic versioning, set up for bento work in 2016
+	// v4.1.0 Converting Google Analytics to use analytics.js (mb)
 
 		var strFormAction;
 
@@ -571,7 +570,13 @@ div#bartonplus_placard iframe {
 	}
 
 	function TrackEvent(Category,Action,Label,Value){
-		_gaq.push(['_trackEvent', Category, Action, Label, Value]);
+		ga('send', {
+			hitType: 'event',
+			eventCategory: Category,
+			eventAction: Action,
+			eventLabel: Label,
+			eventValue: Value
+		});
 	}
 
 </script>

--- a/testing.html
+++ b/testing.html
@@ -216,9 +216,12 @@ div#bartonplus_placard iframe {
 	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
 	// The Production EDS property ID under Google Analytics
-	// ga('create', 'UA-1760176-20', 'auto');
+	// var propertyID = 'UA-1760176-1';
 	// The Development EDS property ID under Google Analytics
-	ga('create', 'UA-1760176-32', 'auto');
+	var propertyID = 'UA-1760176-26';
+	ga('create', propertyID, 'auto', {'allowLinker': true});
+	ga('require', 'linker');
+	ga('linker:autoLink', ['libraries-dev.mit.edu', 'libraries-test.mit.edu'] );
 	ga('send', 'pageview');
 
 	// This comes from the EBSCO Administration wiki


### PR DESCRIPTION
The basic work of this PR is twofold:
* Switches GA profiles to the new combined profile, from the dedicated EDS profile.
* Changes from the old google-anlaytics.js syntax to the new analytics.js syntax.

There may be some incidental tabs-v-spaces updates or whatnot, but this is cosmetic. As a trailing repository, this has also already been deployed in production - so a full review may not be warranted at the moment (this has already happened).