### PR TITLE
[WIP] Refactors changelog

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,50 @@
+# Changelog:
+
+v3.8 Converting Google Analytics to use analytics.js (mb)
+
+v3.7 Removing beta-banner (mb)
+
+v3.6 Added SSO note to beta-banner (mb)
+
+v3.5 Modified footer as per Remlee Green email on 10-06-2014 (rw) 
+
+v3.4 Reworking recording of returned results, and clicks thereupon
+
+v3.3 Changing text in beta banner to just read "Welcome to BartonPlus. Let us know what you think!"
+
+v3.2 Adding pipes between custom links in search result list (CSS only)
+
+v3.1 Added listener for top toolbar
+
+v3.0 Changing listeners for navigation and result list scanning, to keep pace with markup changes in EDS
+
+v2.9 Shrinking placard dimension to 120px with hidden overflow
+
+v2.8 Tweaking "Click Item" routine to better capture link permutations
+
+v2.7 Placard styles
+
+v2.6 Rebuilt left sidebar listener
+
+v2.5 Added plain text source and type strings to result scanning
+     Clicking in result list now identifies titles distinct from fulfillment links
+     Click tracking also stores item type in 'click type' action
+
+v2.4 Improved search result scanning to parse JSON identifier
+     Add scan for dead end result
+     Recording error messages (no results warnings)
+
+v2.3 Added search result scanning
+
+v2.2 Added pagination links
+
+v2.1 Added WorldCat widget on record page
+     Added 'Action' value to "Unknown" case statement to identify what forms we are missing.
+
+v2 Options toolbar of results list
+   Additional tracking of left sidebar filters
+   Branding footer links
+   Links within a result in the list
+   Custom widgets on the record page
+
+v1 Left and right sidebar of results list

--- a/development.html
+++ b/development.html
@@ -1,4 +1,4 @@
-Development footer 3.2
+Development footer
 <style>
 #rtac_panel{display:none !important}
 </style>
@@ -238,32 +238,6 @@ div#bartonplus_placard iframe {
 	// end EBSCO Admin code
 
 	function InitAnalytics(){
-
-// This is the second iteration of tracking code for EDS.
-// Changelog:
-// v1 Left and right sidebar of results list
-// v2 Options toolbar of results list
-//    Additional tracking of left sidebar filters
-//    Branding footer links
-//    Links within a result in the list
-//    Custom widgets on the record page
-// v2.1 Added WorldCat widget on record page
-//    Added 'Action' value to "Unknown" case statement to identify what forms we are missing.
-// v2.2 Added pagination links
-// v2.3 Added search result scanning
-// v2.4 Improved search result scanning to parse JSON identifier
-//      Add scan for dead end result
-//      Recording error messages (no results warnings)
-// v2.5 Added plain text source and type strings to result scanning
-//      Clicking in result list now identifies titles distinct from fulfillment links
-//      Click tracking also stores item type in 'click type' action
-// v2.6 Refactoring left sidebare interactions
-// v2.7 Adding placard styles and event listeners
-// v2.8 Adding listener to top toolbar
-// v2.9 Adding pipes between custom links in search result list (CSS only)
-// v3.0 Reworking recording of returned results, and clicks thereupon
-// v3.1 Removing red "beta-banner" bar as a test
-// v3.2 Switches to new Google Analytics script
 
 		var strFormAction;
 

--- a/production.html
+++ b/production.html
@@ -238,38 +238,6 @@ div#bartonplus_placard iframe {
 
 	function InitAnalytics(){
 
-// This is the second iteration of tracking code for EDS.
-// Changelog:
-// v1 Left and right sidebar of results list
-// v2 Options toolbar of results list
-//    Additional tracking of left sidebar filters
-//    Branding footer links
-//    Links within a result in the list
-//    Custom widgets on the record page
-// v2.1 Added WorldCat widget on record page
-//    Added 'Action' value to "Unknown" case statement to identify what forms we are missing.
-// v2.2 Added pagination links
-// v2.3 Added search result scanning
-// v2.4 Improved search result scanning to parse JSON identifier
-//      Add scan for dead end result
-//      Recording error messages (no results warnings)
-// v2.5 Added plain text source and type strings to result scanning
-//      Clicking in result list now identifies titles distinct from fulfillment links
-//      Click tracking also stores item type in 'click type' action
-// v2.6 Rebuilt left sidebar listener
-// v2.7 Placard styles
-// v2.8 Tweaking "Click Item" routine to better capture link permutations
-// v2.9 Shrinking placard dimension to 120px with hidden overflow
-// v3.0 Changing listeners for navigation and result list scanning, to keep pace with markup changes in EDS
-// v3.1 Added listener for top toolbar
-// v3.2 Adding pipes between custom links in search result list (CSS only)
-// v3.3 Changing text in beta banner to just read "Welcome to BartonPlus. Let us know what you think!"
-// v3.4 Reworking recording of returned results, and clicks thereupon
-// v3.5 Modified footer as per Remlee Green email on 10-06-2014 (rw) 
-// v3.6 Added SSO note to beta-banner (mb)
-// v3.7 Removing beta-banner (mb)
-// v3.8 Converting Google Analytics to use analytics.js (mb)
-
 		var strFormAction;
 
 		// Search forms

--- a/simple-no-js.html
+++ b/simple-no-js.html
@@ -1,3 +1,4 @@
+Simple / no javascript footer
 <style type="text/css">
 <!--
 /* Grids */

--- a/testing-deep-link.html
+++ b/testing-deep-link.html
@@ -1,4 +1,4 @@
-Testing footer 4.0.0 Deep Link Hack
+Testing footer - Deep Link Hack
 <style>
 #rtac_panel{display:none !important}
 </style>
@@ -233,38 +233,6 @@ div#bartonplus_placard iframe {
 	// end EBSCO Admin code
 
 	function InitAnalytics(){
-
-	// This is the second iteration of tracking code for EDS.
-	// Changelog:
-	// v1 Left and right sidebar of results list
-	// v2 Options toolbar of results list
-	//    Additional tracking of left sidebar filters
-	//    Branding footer links
-	//    Links within a result in the list
-	//    Custom widgets on the record page
-	// v2.1 Added WorldCat widget on record page
-	//    Added 'Action' value to "Unknown" case statement to identify what forms we are missing.
-	// v2.2 Added pagination links
-	// v2.3 Added search result scanning
-	// v2.4 Improved search result scanning to parse JSON identifier
-	//      Add scan for dead end result
-	//      Recording error messages (no results warnings)
-	// v2.5 Added plain text source and type strings to result scanning
-	//      Clicking in result list now identifies titles distinct from fulfillment links
-	//      Click tracking also stores item type in 'click type' action
-	// v2.6 Rebuilt left sidebar listener
-	// v2.7 Placard styles
-	// v2.8 Tweaking "Click Item" routine to better capture link permutations
-	// v2.9 Shrinking placard dimension to 120px with hidden overflow
-	// v3.0 Changing listeners for navigation and result list scanning, to keep pace with markup changes in EDS
-	// v3.1 Added listener for top toolbar
-	// v3.2 Adding pipes between custom links in search result list (CSS only)
-	// v3.3 Changing text in beta banner to just read "Welcome to BartonPlus. Let us know what you think!"
-	// v3.4 Reworking recording of returned results, and clicks thereupon
-	// v3.5 Modified footer as per Remlee Green email on 10-06-2014 (rw) 
-	// v3.6 Added SSO note to beta-banner (mb)
-	// v3.7 Removing beta-banner (mb)
-	// v4.0.0 Semantic versioning, set up for bento work in 2016
 
 		var strFormAction;
 

--- a/testing.html
+++ b/testing.html
@@ -1,4 +1,4 @@
-Testing footer 4.1.0
+Testing footer
 <style>
 #rtac_panel{display:none !important}
 </style>
@@ -238,39 +238,6 @@ div#bartonplus_placard iframe {
 	// end EBSCO Admin code
 
 	function InitAnalytics(){
-
-	// This is the second iteration of tracking code for EDS.
-	// Changelog:
-	// v1 Left and right sidebar of results list
-	// v2 Options toolbar of results list
-	//    Additional tracking of left sidebar filters
-	//    Branding footer links
-	//    Links within a result in the list
-	//    Custom widgets on the record page
-	// v2.1 Added WorldCat widget on record page
-	//    Added 'Action' value to "Unknown" case statement to identify what forms we are missing.
-	// v2.2 Added pagination links
-	// v2.3 Added search result scanning
-	// v2.4 Improved search result scanning to parse JSON identifier
-	//      Add scan for dead end result
-	//      Recording error messages (no results warnings)
-	// v2.5 Added plain text source and type strings to result scanning
-	//      Clicking in result list now identifies titles distinct from fulfillment links
-	//      Click tracking also stores item type in 'click type' action
-	// v2.6 Rebuilt left sidebar listener
-	// v2.7 Placard styles
-	// v2.8 Tweaking "Click Item" routine to better capture link permutations
-	// v2.9 Shrinking placard dimension to 120px with hidden overflow
-	// v3.0 Changing listeners for navigation and result list scanning, to keep pace with markup changes in EDS
-	// v3.1 Added listener for top toolbar
-	// v3.2 Adding pipes between custom links in search result list (CSS only)
-	// v3.3 Changing text in beta banner to just read "Welcome to BartonPlus. Let us know what you think!"
-	// v3.4 Reworking recording of returned results, and clicks thereupon
-	// v3.5 Modified footer as per Remlee Green email on 10-06-2014 (rw) 
-	// v3.6 Added SSO note to beta-banner (mb)
-	// v3.7 Removing beta-banner (mb)
-	// v4.0.0 Semantic versioning, set up for bento work in 2016
-	// v4.1.0 Converting Google Analytics to use analytics.js (mb)
 
 		var strFormAction;
 


### PR DESCRIPTION
This removes comment-level changelog from all footers. In its place, we create a changelog markdown file based on the changes listed in the production footer.

Other changelogs are discarded, as we only intend to maintain one footer. Other files in this repo are for testing and development purposes en route to changing the one production footer.