### PR TITLE
Adds detail page listeners

### DIFF
--- a/development.html
+++ b/development.html
@@ -534,6 +534,11 @@ div#bartonplus_placard iframe {
 		jQuery("div#worldcatplaceholder").click(function() {
 			TrackEvent('Custom Widget','Request from non-MIT Libraries','Click',1);
 		});
+		// Right sidebar tools
+		jQuery(".article-tool a").click(function() {
+			strToolName = jQuery(this).attr('title');
+			TrackEvent('Detail Page','Sidebar',strToolName,1);
+		});
 
 		/* ####################################################################
 		####

--- a/development.html
+++ b/development.html
@@ -554,6 +554,14 @@ div#bartonplus_placard iframe {
 				TrackEvent('Detail Page', 'Tool Use ' + event.target.type, panel, 1);
 			}
 		});
+		// RTAC panel
+		jQuery("body.detail .rtac-table a").click(function() {
+			TrackEvent('Detail Page', 'RTAC Table', jQuery(this).text().trim(), 1);
+		});
+		// Navigation
+		jQuery("body.detail .nav-list a").click(function() {
+			TrackEvent('Detail Page', 'Pagination', jQuery(this).text().trim(), 1);
+		});
 
 		/* ####################################################################
 		####

--- a/development.html
+++ b/development.html
@@ -526,6 +526,14 @@ div#bartonplus_placard iframe {
 		####
 		#### Record Page
 		# */
+		// Left sidebar
+		jQuery("body.detail #column1 a").click(function() {
+			var strLinkText = jQuery(this).text().trim();
+			if(!strLinkText) {
+				strLinkText = jQuery(this).attr('id');
+			}
+			TrackEvent('Detail Page', 'Left Sidebar', strLinkText, 1);
+		});
 		// Custom widgets (Google Scholar, etc)
 		jQuery("div.custom-widget a").click(function() {
 			strWidgetName = jQuery(this).closest("div").attr('data-key');

--- a/development.html
+++ b/development.html
@@ -540,9 +540,11 @@ div#bartonplus_placard iframe {
 			TrackEvent('Detail Page','Sidebar',strToolName,1);
 		});
 		// Tool form (triggered by right sidebar)
-		jQuery('#ToolPanelContent input').click(function() {
-			strToolName = jQuery(this).attr('value');
-			TrackEvent('Detail Page','Tool Use',strToolName,1);
+		jQuery("#ToolPanelContent").click(function( event ) {
+			if ("submit" === event.target.type) {
+				var panel = jQuery("#ToolPanelContent h2.panel-header").text().trim();
+				TrackEvent('Detail Page', 'Tool Use ' + event.target.type, panel, 1);
+			}
 		});
 
 		/* ####################################################################

--- a/development.html
+++ b/development.html
@@ -539,6 +539,11 @@ div#bartonplus_placard iframe {
 			strToolName = jQuery(this).attr('title');
 			TrackEvent('Detail Page','Sidebar',strToolName,1);
 		});
+		// Tool form (triggered by right sidebar)
+		jQuery('#ToolPanelContent input').click(function() {
+			strToolName = jQuery(this).attr('value');
+			TrackEvent('Detail Page','Tool Use',strToolName,1);
+		});
 
 		/* ####################################################################
 		####

--- a/production.html
+++ b/production.html
@@ -502,6 +502,14 @@ div#bartonplus_placard iframe {
 		####
 		#### Record Page
 		# */
+		// Left sidebar
+		jQuery("body.detail #column1 a").click(function() {
+			var strLinkText = jQuery(this).text().trim();
+			if(!strLinkText) {
+				strLinkText = jQuery(this).attr('id');
+			}
+			TrackEvent('Detail Page', 'Left Sidebar', strLinkText, 1);
+		});
 		// Custom widgets (Google Scholar, etc)
 		jQuery("div.custom-widget a").click(function() {
 			strWidgetName = jQuery(this).closest("div").attr('data-key');
@@ -509,6 +517,26 @@ div#bartonplus_placard iframe {
 		});
 		jQuery("div#worldcatplaceholder").click(function() {
 			TrackEvent('Custom Widget','Request from non-MIT Libraries','Click',1);
+		});
+		// Right sidebar tools
+		jQuery(".article-tool a").click(function() {
+			strToolName = jQuery(this).attr('title');
+			TrackEvent('Detail Page','Sidebar',strToolName,1);
+		});
+		// Tool form (triggered by right sidebar)
+		jQuery("#ToolPanelContent").click(function( event ) {
+			if ("submit" === event.target.type) {
+				var panel = jQuery("#ToolPanelContent h2.panel-header").text().trim();
+				TrackEvent('Detail Page', 'Tool Use ' + event.target.type, panel, 1);
+			}
+		});
+		// RTAC panel
+		jQuery("body.detail .rtac-table a").click(function() {
+			TrackEvent('Detail Page', 'RTAC Table', jQuery(this).text().trim(), 1);
+		});
+		// Navigation
+		jQuery("body.detail .nav-list a").click(function() {
+			TrackEvent('Detail Page', 'Pagination', jQuery(this).text().trim(), 1);
 		});
 
 

--- a/testing-deep-link.html
+++ b/testing-deep-link.html
@@ -503,6 +503,14 @@ div#bartonplus_placard iframe {
 		####
 		#### Record Page
 		# */
+		// Left sidebar
+		jQuery("body.detail #column1 a").click(function() {
+			var strLinkText = jQuery(this).text().trim();
+			if(!strLinkText) {
+				strLinkText = jQuery(this).attr('id');
+			}
+			TrackEvent('Detail Page', 'Left Sidebar', strLinkText, 1);
+		});
 		// Custom widgets (Google Scholar, etc)
 		jQuery("div.custom-widget a").click(function() {
 			strWidgetName = jQuery(this).closest("div").attr('data-key');
@@ -510,6 +518,26 @@ div#bartonplus_placard iframe {
 		});
 		jQuery("div#worldcatplaceholder").click(function() {
 			TrackEvent('Custom Widget','Request from non-MIT Libraries','Click',1);
+		});
+		// Right sidebar tools
+		jQuery(".article-tool a").click(function() {
+			strToolName = jQuery(this).attr('title');
+			TrackEvent('Detail Page','Sidebar',strToolName,1);
+		});
+		// Tool form (triggered by right sidebar)
+		jQuery("#ToolPanelContent").click(function( event ) {
+			if ("submit" === event.target.type) {
+				var panel = jQuery("#ToolPanelContent h2.panel-header").text().trim();
+				TrackEvent('Detail Page', 'Tool Use ' + event.target.type, panel, 1);
+			}
+		});
+		// RTAC panel
+		jQuery("body.detail .rtac-table a").click(function() {
+			TrackEvent('Detail Page', 'RTAC Table', jQuery(this).text().trim(), 1);
+		});
+		// Navigation
+		jQuery("body.detail .nav-list a").click(function() {
+			TrackEvent('Detail Page', 'Pagination', jQuery(this).text().trim(), 1);
 		});
 
 

--- a/testing.html
+++ b/testing.html
@@ -509,6 +509,14 @@ div#bartonplus_placard iframe {
 		####
 		#### Record Page
 		# */
+		// Left sidebar
+		jQuery("body.detail #column1 a").click(function() {
+			var strLinkText = jQuery(this).text().trim();
+			if(!strLinkText) {
+				strLinkText = jQuery(this).attr('id');
+			}
+			TrackEvent('Detail Page', 'Left Sidebar', strLinkText, 1);
+		});
 		// Custom widgets (Google Scholar, etc)
 		jQuery("div.custom-widget a").click(function() {
 			strWidgetName = jQuery(this).closest("div").attr('data-key');
@@ -516,6 +524,26 @@ div#bartonplus_placard iframe {
 		});
 		jQuery("div#worldcatplaceholder").click(function() {
 			TrackEvent('Custom Widget','Request from non-MIT Libraries','Click',1);
+		});
+		// Right sidebar tools
+		jQuery(".article-tool a").click(function() {
+			strToolName = jQuery(this).attr('title');
+			TrackEvent('Detail Page','Sidebar',strToolName,1);
+		});
+		// Tool form (triggered by right sidebar)
+		jQuery("#ToolPanelContent").click(function( event ) {
+			if ("submit" === event.target.type) {
+				var panel = jQuery("#ToolPanelContent h2.panel-header").text().trim();
+				TrackEvent('Detail Page', 'Tool Use ' + event.target.type, panel, 1);
+			}
+		});
+		// RTAC panel
+		jQuery("body.detail .rtac-table a").click(function() {
+			TrackEvent('Detail Page', 'RTAC Table', jQuery(this).text().trim(), 1);
+		});
+		// Navigation
+		jQuery("body.detail .nav-list a").click(function() {
+			TrackEvent('Detail Page', 'Pagination', jQuery(this).text().trim(), 1);
 		});
 
 


### PR DESCRIPTION
This adds a number of event listeners that are targeted to the detail page of EDS. Specifically:

1) interactions with the right tools sidebar - both the icons in the right sidebar, and then the placard form that several of them cause to appear.

2) left sidebar interactions, things like "get it in the library" / SFX or "more like this" searches.

3) Interactions with the RTAC table in the main column, linking to Barton for "get MIT copy"